### PR TITLE
add support for legacy min, max

### DIFF
--- a/nutils/SI.py
+++ b/nutils/SI.py
@@ -183,7 +183,7 @@ class Quantity(metaclass=Dimension):
             Dim = type(args[0]) * type(args[1])
         elif name in ('truediv', 'true_divide', 'divide'):
             Dim = type(args[0]) / type(args[1])
-        elif name in ('neg', 'negative', 'pos', 'positive', 'abs', 'absolute', 'sum', 'mean', 'broadcast_to', 'transpose', 'trace', 'take', 'ptp', 'getitem', 'amax', 'amin'):
+        elif name in ('neg', 'negative', 'pos', 'positive', 'abs', 'absolute', 'sum', 'mean', 'broadcast_to', 'transpose', 'trace', 'take', 'ptp', 'getitem', 'amax', 'amin', 'max', 'min'):
             Dim = type(args[0])
         elif name == 'sqrt':
             Dim = type(args[0])**fractions.Fraction(1,2)


### PR DESCRIPTION
This patch adds legacy support for dispatch of min and max for older versions of Numpy. Later version dispatch to amin and amax, respectively, which were already supported.